### PR TITLE
TEL-5526 update dependencies

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,11 +1,10 @@
-import play.core.PlayVersion
 import play.sbt.PlayImport
-import sbt._
+import sbt.*
 
 object AppDependencies {
 
-  val hmrcBootstrapVersion = "9.12.0"
-  val hmrcMongoVersion     = "2.6.0"
+  val hmrcBootstrapVersion = "10.1.0"
+  val hmrcMongoVersion     = "2.7.0"
   val mockitoVersion       = "1.17.30"
   val flexmarkVersion      = "0.64.8"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.10
+sbt.version=1.11.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,5 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.7")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.8")
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"        % "0.6.4")


### PR DESCRIPTION
# What did we do?
Updated dependencies to latest versions including vulnerability in `jackson-core`.

# References
https://jira.tools.tax.service.gov.uk/browse/TEL-5526

# Evidence of work
Updated:
1. AppDependencies.scala
    - hmrcBootstrapVersion from `9.12.0` to `10.1.0`
    - hmrcMongoVersion from `2.6.0` to `2.7.0`
2. plugins.sbt
    - `org.playframework` `sbt-plugin` from `3.0.7` to `3.0.8`
3. build.properties
    - sbt.version from `1.10.10` to `1.11.4`

Tested locally:
```
[info] GET /zone-health with no downstream to check
[info] - should return 200
[info] ZoneHealthServiceSpec:
[info] ZoneHealthService
[info] - should return Right when a dependent service is OK and mongo-health has returned correctly
[info] - should return Left when a dependent service has Failed and mongo-health has returned correctly
[info] - should return Left when a dependent service is available and mongo-health has failed to write
[info] - should return Left when a dependent service is available and mongo-health has failed to read back the token
[info] - should return Left when a dependent service is available and mongo-health got an exception when reading back the token
[info] ZoneHealthConnectorSpec:
[info] ZoneHealthConnector
[info] - should not try to connect to downstream when none is configured
[info] - should return Some(500) when downstream is configured and returns 500
[info] - should return Some(500) when downstream is configured and the call fails
[info] - should return Some(200) when downstream is configured and returns 200
[info] Run completed in 3 seconds, 45 milliseconds.
[info] Total number of tests run: 10
[info] Suites: completed 3, aborted 0
[info] Tests: succeeded 10, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed. 
```
Jackson-core updated:
```
[info]         | +-com.fasterxml.jackson.core:jackson-core:2.14.3 (evicted by: 2.15.3)
[info]         | +-com.fasterxml.jackson.core:jackson-core:2.15.3
```

# Next steps
- Merge and verify via catalogue

# Risks
- Low. Local testing successful.

# Collaboration
Co-authored-by: @nisartahir 