### PR TITLE
TEL-5817 bump versions of dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import uk.gov.hmrc.DefaultBuildSettings
 
-ThisBuild / scalaVersion := "2.13.16"
+ThisBuild / scalaVersion := "2.13.18"
 ThisBuild / majorVersion := 0
 
 lazy val microservice = Project("zone-health", file("."))

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,15 @@
+[tools]
+sbt = "1.11.4"
+scala = "2.13.18"
+
+[tasks.test]
+run = "sbt clean test"
+depends = ["docker_up"]
+depends_post = ["docker_down"]
+
+[tasks.docker_up]
+run = "docker-compose -f it/test/resources/docker-compose.yml up -d"
+
+[tasks.docker_down]
+run = "docker-compose -f it/test/resources/docker-compose.yml down"
+

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,8 +3,8 @@ import sbt.*
 
 object AppDependencies {
 
-  val hmrcBootstrapVersion = "10.1.0"
-  val hmrcMongoVersion     = "2.7.0"
+  val hmrcBootstrapVersion = "10.7.0"
+  val hmrcMongoVersion     = "2.12.0"
   val mockitoVersion       = "1.17.30"
   val flexmarkVersion      = "0.64.8"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,5 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.8")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.10")
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"        % "0.6.4")


### PR DESCRIPTION
What did we do?
--

1. Added basic mise config
3. Bump dependency versions 

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-5817

Evidence of work
--

```
❯ mise run test
❯ mise run test
[docker_up] $ docker-compose -f it/test/resources/docker-compose.yml up -d
WARN[0000] No services to build                         
[+] up 2/2
 ✔ Network resources_default   Created                                                                                                                                                                                                            0.0s 
 ✔ Container resources-mongo-1 Created                                                                                                                                                                                                            0.0s 
[test] $ sbt clean test
[info] welcome to sbt 1.11.4 (Eclipse Adoptium Java 21.0.10)
[info] loading settings for project zone-health-build from plugins.sbt...
[info] loading project definition from /Users/damonwright/workspace/hmrc/github/telemetry/zone-health/project
[info] compiling 1 Scala source to /Users/damonwright/workspace/hmrc/github/telemetry/zone-health/project/target/scala-2.12/sbt-1.0/classes ...
[info] SbtAutoBuildPlugin - adding projectSettings
[info] loading settings for project zone-health from build.sbt...
[info] SbtAutoBuildPlugin - adding projectSettings
[info] SbtAutoBuildPlugin - adding global settings
[info] SbtAutoBuildPlugin - repository is marked public. Licence headers will be added to all source files
[info] SbtAutoBuildPlugin - repository is marked public. Licence headers will be added to all source files
[info]   __              __
[info]   \ \     ____   / /____ _ __  __
[info]    \ \   / __ \ / // __ `// / / /
[info]    / /  / /_/ // // /_/ // /_/ /
[info]   /_/  / .___//_/ \__,_/ \__, /
[info]       /_/               /____/
[info] 
[info] Version 3.0.10 running Java 21.0.10
[info] 
[info] Play is run entirely by the community. Please consider contributing and/or donating:
[info] https://www.playframework.com/sponsors
[info] 
[success] Total time: 0 s, completed 9 Mar 2026, 16:13:26
[info] compiling 13 Scala sources and 1 Java source to /Users/damonwright/workspace/hmrc/github/telemetry/zone-health/target/scala-2.13/classes ...
[info] compiling 3 Scala sources to /Users/damonwright/workspace/hmrc/github/telemetry/zone-health/target/scala-2.13/test-classes ...
[info] ZoneHealthControllerSpec:
16:13:32.310 [pool-1-thread-1] INFO play.api.http.HttpErrorHandlerExceptions -- Registering exception handler: guice-provision-exception-handler
WARN  application - Logger configuration in conf files is deprecated and has no effect. Use a logback configuration file instead.
[info] GET /zone-health with no downstream to check
[info] - should return 200
[info] ZoneHealthServiceSpec:
[info] ZoneHealthService
[info] - should return Right when a dependent service is OK and mongo-health has returned correctly
[info] - should return Left when a dependent service has Failed and mongo-health has returned correctly
[info] - should return Left when a dependent service is available and mongo-health has failed to write
[info] - should return Left when a dependent service is available and mongo-health has failed to read back the token
[info] - should return Left when a dependent service is available and mongo-health got an exception when reading back the token
[info] ZoneHealthConnectorSpec:
[info] ZoneHealthConnector
[info] - should not try to connect to downstream when none is configured
[info] - should return Some(500) when downstream is configured and returns 500
[info] - should return Some(500) when downstream is configured and the call fails
[info] - should return Some(200) when downstream is configured and returns 200
[info] Run completed in 2 seconds, 489 milliseconds.
[info] Total number of tests run: 10
[info] Suites: completed 3, aborted 0
[info] Tests: succeeded 10, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 7 s, completed 9 Mar 2026, 16:13:33
[docker_down] $ docker-compose -f it/test/resources/docker-compose.yml down
[+] down 2/2
 ✔ Container resources-mongo-1 Removed                                                                                                                                                                                                            0.4s 
 ✔ Network resources_default   Removed                                                                                                                                                                                                            0.5s 
Finished in 14.23s
```

Next Steps
--

1. Check if new version passed bobby rules

Risks
--

1. Low - tests pass and only minor version changes to dependencies

Collaboration
--